### PR TITLE
refactor: Renumber test plan steps sequentially

### DIFF
--- a/TestSuiteFiles/EM100_Test_Plan.md
+++ b/TestSuiteFiles/EM100_Test_Plan.md
@@ -34,11 +34,11 @@ To ensure the supply fan module correctly responds to start/stop commands and th
 *   **Test Steps:**
 | Test ID | Test Step Name | Parameter | Value | Comment |
 | :--- | :--- | :--- | :--- | :--- |
-| 1.0 | **Initial State** | `#Instance_DB.Enable` | `TRUE` | Enable the fan module. |
-| 1.1 | | `#Instance_DB.UDT.Fault_Delay_Sec`| `T#5s` | Set fault delay for the test. |
-| 2.0 | **Wait for Fault** | `#WAIT` | `5000` | Wait for 5000 ms. |
-| 2.1 | *Evaluate* | `#Instance_DB.UDT.Fan_Failure_Alm`| `TRUE` | **Check:** The failure alarm is now active. |
-| 2.2 | *Evaluate* | `#Instance_DB.UDT.Start_Cmd_DO` | `FALSE` | **Check:** The start command is disabled on fault. |
+| 4.0 | **Initial State** | `#Instance_DB.Enable` | `TRUE` | Enable the fan module. |
+| 4.1 | | `#Instance_DB.UDT.Fault_Delay_Sec`| `T#5s` | Set fault delay for the test. |
+| 5.0 | **Wait for Fault** | `#WAIT` | `5000` | Wait for 5000 ms. |
+| 5.1 | *Evaluate* | `#Instance_DB.UDT.Fan_Failure_Alm`| `TRUE` | **Check:** The failure alarm is now active. |
+| 5.2 | *Evaluate* | `#Instance_DB.UDT.Start_Cmd_DO` | `FALSE` | **Check:** The start command is disabled on fault. |
 
 ### Test Case 3: VFD Fault Trip
 
@@ -47,8 +47,8 @@ To ensure the supply fan module correctly responds to start/stop commands and th
 *   **Test Steps:**
 | Test ID | Test Step Name | Parameter | Value | Comment |
 | :--- | :--- | :--- | :--- | :--- |
-| 1.0 | **Initial State** | `#Instance_DB.Enable` | `TRUE` | Fan is running. |
-| 1.1 | | `#Instance_DB.UDT.Run_Fdbk_DI` | `TRUE` | |
-| 2.0 | **Simulate VFD Fault**| `#Instance_DB.UDT.VFD_Fault_DI`| `TRUE` | |
-| 2.1 | *Evaluate* | `#Instance_DB.UDT.VFD_Fault_Alm` | `TRUE` | **Check:** VFD Fault alarm is active. |
-| 2.2 | *Evaluate* | `#Instance_DB.UDT.Start_Cmd_DO` | `FALSE`| **Check:** Start command is immediately turned off. |
+| 6.0 | **Initial State** | `#Instance_DB.Enable` | `TRUE` | Fan is running. |
+| 6.1 | | `#Instance_DB.UDT.Run_Fdbk_DI` | `TRUE` | |
+| 7.0 | **Simulate VFD Fault**| `#Instance_DB.UDT.VFD_Fault_DI`| `TRUE` | |
+| 7.1 | *Evaluate* | `#Instance_DB.UDT.VFD_Fault_Alm` | `TRUE` | **Check:** VFD Fault alarm is active. |
+| 7.2 | *Evaluate* | `#Instance_DB.UDT.Start_Cmd_DO` | `FALSE`| **Check:** Start command is immediately turned off. |

--- a/TestSuiteFiles/EM200_Test_Plan.md
+++ b/TestSuiteFiles/EM200_Test_Plan.md
@@ -33,8 +33,8 @@ To ensure the cooling module correctly passes an analog demand signal to its val
 *   **Test Steps:**
 | Test ID | Test Step Name | Parameter | Value | Comment |
 | :--- | :--- | :--- | :--- | :--- |
-| 1.0 | **Initial State** | `#Instance_DB.Valve_Demand_In` | `75.0` | Set demand to 75%. |
-| 1.1 | *Evaluate* | `#Instance_DB.UDT.CHW_Valve_Cmd_AO`| `75.0` | **Check:** Valve is commanded open. |
-| 2.0 | **Simulate Fault** | `#Instance_DB.UDT.CHW_Freeze_Stat_DI`| `TRUE` | Simulate the freeze stat tripping. |
-| 2.1 | *Evaluate* | `#Instance_DB.UDT.CHW_Freeze_Alm`| `TRUE` | **Check:** The freeze alarm is now active. |
-| 2.2 | *Evaluate* | `#Instance_DB.UDT.CHW_Valve_Cmd_AO`| `0.0` | **Check:** Valve is commanded fully closed on fault, ignoring the input demand. |
+| 3.0 | **Initial State** | `#Instance_DB.Valve_Demand_In` | `75.0` | Set demand to 75%. |
+| 3.1 | *Evaluate* | `#Instance_DB.UDT.CHW_Valve_Cmd_AO`| `75.0` | **Check:** Valve is commanded open. |
+| 4.0 | **Simulate Fault** | `#Instance_DB.UDT.CHW_Freeze_Stat_DI`| `TRUE` | Simulate the freeze stat tripping. |
+| 4.1 | *Evaluate* | `#Instance_DB.UDT.CHW_Freeze_Alm`| `TRUE` | **Check:** The freeze alarm is now active. |
+| 4.2 | *Evaluate* | `#Instance_DB.UDT.CHW_Valve_Cmd_AO`| `0.0` | **Check:** Valve is commanded fully closed on fault, ignoring the input demand. |

--- a/TestSuiteFiles/EM300_Test_Plan.md
+++ b/TestSuiteFiles/EM300_Test_Plan.md
@@ -33,8 +33,8 @@ To ensure the heating module correctly passes an analog demand signal to its val
 *   **Test Steps:**
 | Test ID | Test Step Name | Parameter | Value | Comment |
 | :--- | :--- | :--- | :--- | :--- |
-| 1.0 | **Initial State** | `#Instance_DB.Valve_Demand_In` | `75.0` | Set demand to 75%. |
-| 1.1 | *Evaluate* | `#Instance_DB.UDT.HW_Valve_Cmd_AO`| `75.0` | **Check:** Valve is commanded open. |
-| 2.0 | **Simulate Fault** | `#Instance_DB.UDT.HW_Freeze_Stat_DI`| `TRUE` | Simulate the freeze stat tripping. |
-| 2.1 | *Evaluate* | `#Instance_DB.UDT.HW_Freeze_Alm`| `TRUE` | **Check:** The freeze alarm is now active. |
-| 2.2 | *Evaluate* | `#Instance_DB.UDT.HW_Valve_Cmd_AO`| `0.0` | **Check:** Valve is commanded fully closed on fault, ignoring the input demand. |
+| 3.0 | **Initial State** | `#Instance_DB.Valve_Demand_In` | `75.0` | Set demand to 75%. |
+| 3.1 | *Evaluate* | `#Instance_DB.UDT.HW_Valve_Cmd_AO`| `75.0` | **Check:** Valve is commanded open. |
+| 4.0 | **Simulate Fault** | `#Instance_DB.UDT.HW_Freeze_Stat_DI`| `TRUE` | Simulate the freeze stat tripping. |
+| 4.1 | *Evaluate* | `#Instance_DB.UDT.HW_Freeze_Alm`| `TRUE` | **Check:** The freeze alarm is now active. |
+| 4.2 | *Evaluate* | `#Instance_DB.UDT.HW_Valve_Cmd_AO`| `0.0` | **Check:** Valve is commanded fully closed on fault, ignoring the input demand. |

--- a/TestSuiteFiles/EM400_Test_Plan.md
+++ b/TestSuiteFiles/EM400_Test_Plan.md
@@ -31,7 +31,7 @@ To ensure the damper module correctly drives to the minimum ventilation position
 *   **Test Steps:**
 | Test ID | Test Step Name | Parameter | Value | Comment |
 | :--- | :--- | :--- | :--- | :--- |
-| 1.0 | **Initial State** | `#Instance_DB.Enable` | `TRUE` | |
-| 1.1 | | `#Instance_DB.Econ_Mode_Active`| `TRUE` | Activate economizer mode. |
-| 1.2 | | `#Instance_DB.Econ_PID_Demand` | `65.0` | Simulate 65% demand from economizer PID. |
-| 1.3 | *Evaluate* | `#Instance_DB.UDT.Damper_Pos_Cmd_AO`| `65.0` | **Check:** Damper command follows the PID demand. |
+| 2.0 | **Initial State** | `#Instance_DB.Enable` | `TRUE` | |
+| 2.1 | | `#Instance_DB.Econ_Mode_Active`| `TRUE` | Activate economizer mode. |
+| 2.2 | | `#Instance_DB.Econ_PID_Demand` | `65.0` | Simulate 65% demand from economizer PID. |
+| 2.3 | *Evaluate* | `#Instance_DB.UDT.Damper_Pos_Cmd_AO`| `65.0` | **Check:** Damper command follows the PID demand. |

--- a/TestSuiteFiles/Integration_Test_Plan.md
+++ b/TestSuiteFiles/Integration_Test_Plan.md
@@ -44,11 +44,11 @@ To ensure the main PID controller correctly responds to changes in temperature b
 *   **Test Steps:**
 | Test ID | Test Step Name | Parameter | Value | Comment |
 | :--- | :--- | :--- | :--- | :--- |
-| 1.0 | **Initial State** | `Setpoint` | `70.0` | |
-| 1.1 | | `AHU1_DAT_Temp` | `70.0` | |
-| 1.2 | *Evaluate* | `Output` | `0.0` | **Check:** PID output should be zero. |
-| 2.0 | **Simulate Cool Demand**| `AHU1_DAT_Temp` | `75.0` | Force temperature above setpoint. |
-| 2.1 | *Evaluate* | `Output` | `> 0.0` | **Check:** PID output is positive, demanding cooling. |
+| 3.0 | **Initial State** | `Setpoint` | `70.0` | |
+| 3.1 | | `AHU1_DAT_Temp` | `70.0` | |
+| 3.2 | *Evaluate* | `Output` | `0.0` | **Check:** PID output should be zero. |
+| 4.0 | **Simulate Cool Demand**| `AHU1_DAT_Temp` | `75.0` | Force temperature above setpoint. |
+| 4.1 | *Evaluate* | `Output` | `> 0.0` | **Check:** PID output is positive, demanding cooling. |
 
 ### Test Case 3: Output Clamping (Upper Limit)
 
@@ -57,10 +57,10 @@ To ensure the main PID controller correctly responds to changes in temperature b
 *   **Test Steps:**
 | Test ID | Test Step Name | Parameter | Value | Comment |
 | :--- | :--- | :--- | :--- | :--- |
-| 1.0 | **Initial State** | `Setpoint` | `70.0` | |
-| 1.1 | | `OutputUpperLimit` | `100.0`| |
-| 2.0 | **Force High Error**| `AHU1_DAT_Temp` | `90.0` | Force a large temperature error to drive output high. |
-| 2.1 | *Evaluate* | `Output` | `100.0` | **Check:** PID output is clamped exactly at the upper limit. |
+| 5.0 | **Initial State** | `Setpoint` | `70.0` | |
+| 5.1 | | `OutputUpperLimit` | `100.0`| |
+| 6.0 | **Force High Error**| `AHU1_DAT_Temp` | `90.0` | Force a large temperature error to drive output high. |
+| 6.1 | *Evaluate* | `Output` | `100.0` | **Check:** PID output is clamped exactly at the upper limit. |
 
 ### Test Case 4: Output Clamping (Lower Limit)
 
@@ -69,7 +69,7 @@ To ensure the main PID controller correctly responds to changes in temperature b
 *   **Test Steps:**
 | Test ID | Test Step Name | Parameter | Value | Comment |
 | :--- | :--- | :--- | :--- | :--- |
-| 1.0 | **Initial State** | `Setpoint` | `70.0` | |
-| 1.1 | | `OutputLowerLimit` | `-100.0`| |
-| 2.0 | **Force High Error**| `AHU1_DAT_Temp` | `50.0` | Force a large temperature error to drive output low. |
-| 2.1 | *Evaluate* | `Output` | `-100.0` | **Check:** PID output is clamped exactly at the lower limit. |
+| 7.0 | **Initial State** | `Setpoint` | `70.0` | |
+| 7.1 | | `OutputLowerLimit` | `-100.0`| |
+| 8.0 | **Force High Error**| `AHU1_DAT_Temp` | `50.0` | Force a large temperature error to drive output low. |
+| 8.1 | *Evaluate* | `Output` | `-100.0` | **Check:** PID output is clamped exactly at the lower limit. |


### PR DESCRIPTION
Based on user feedback for a more professional format, this commit updates all six test plan documents in the `TestSuiteFiles/` directory.

The `Test ID` column in each markdown file has been renumbered to be globally sequential, rather than resetting for each test case. This improves readability and makes referencing specific test steps easier.